### PR TITLE
fix: bump hilla version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <properties>
         <java.version>11</java.version>
-        <hilla.version>1.1.4</hilla.version>
+        <hilla.version>1.2.0.beta1</hilla.version>
         <selenium.version>4.2.1</selenium.version>
     </properties>
 


### PR DESCRIPTION
This is needed to have 23.2.X Vaadin components installed (required by `react-vaadin-components`)