### PR TITLE
chore: bump react-vaadin-components version, cleanup

### DIFF
--- a/frontend/features/contacts/Contacts.tsx
+++ b/frontend/features/contacts/Contacts.tsx
@@ -16,8 +16,8 @@ export default function Contacts() {
   const filterChanged = (e: TextFieldElement.TextFieldValueChangedEvent) => dispatch(updateFilter(e.detail.value));
 
   // TODO: fix event type
-  const handleGridSelection = (e: GridElement.GridActiveItemChangedEvent<any>) => {
-    dispatch(selectContact(e.detail.value as Contact));
+  const handleGridSelection = (e: GridElement.GridActiveItemChangedEvent<Contact>) => {
+    dispatch(selectContact(e.detail.value));
   }
 
   const addContact = () => dispatch(selectContact({} as Contact));

--- a/package-lock.json
+++ b/package-lock.json
@@ -141,7 +141,7 @@
         "react-dom": "^18.2.0",
         "react-redux": "^8.0.2",
         "react-router-dom": "^6.3.0",
-        "react-vaadin-components": "^1.0.0-alpha.2",
+        "react-vaadin-components": "^1.0.0-alpha.3",
         "recharts": "^2.1.13",
         "yup": "^0.32.11"
       },
@@ -7556,9 +7556,9 @@
       }
     },
     "node_modules/react-vaadin-components": {
-      "version": "1.0.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/react-vaadin-components/-/react-vaadin-components-1.0.0-alpha.2.tgz",
-      "integrity": "sha512-hmvFeoyISM5j6vqErp9LVw7q8cw8epidwPxMf7+X1FLQWKAy1KtGAkFAzG3zH4buKz1TKYdkjk2a6GKjbJTHVA==",
+      "version": "1.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/react-vaadin-components/-/react-vaadin-components-1.0.0-alpha.3.tgz",
+      "integrity": "sha512-5PPvI4vyCTwWuk4D4McA6euAIMhCU4bfGD9d+dJOuihhUddnDCrf+Qeu5rNoYOelDFKssKBlYwUDfW8wFrqtjQ==",
       "dependencies": {
         "@lit-labs/react": "^1.0.6",
         "@vaadin/vaadin-core": "23.2.0-beta2",
@@ -14696,9 +14696,9 @@
       }
     },
     "react-vaadin-components": {
-      "version": "1.0.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/react-vaadin-components/-/react-vaadin-components-1.0.0-alpha.2.tgz",
-      "integrity": "sha512-hmvFeoyISM5j6vqErp9LVw7q8cw8epidwPxMf7+X1FLQWKAy1KtGAkFAzG3zH4buKz1TKYdkjk2a6GKjbJTHVA==",
+      "version": "1.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/react-vaadin-components/-/react-vaadin-components-1.0.0-alpha.3.tgz",
+      "integrity": "sha512-5PPvI4vyCTwWuk4D4McA6euAIMhCU4bfGD9d+dJOuihhUddnDCrf+Qeu5rNoYOelDFKssKBlYwUDfW8wFrqtjQ==",
       "requires": {
         "@lit-labs/react": "^1.0.6",
         "@vaadin/vaadin-core": "23.2.0-beta2",

--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.2",
     "react-router-dom": "^6.3.0",
-    "react-vaadin-components": "^1.0.0-alpha.2",
+    "react-vaadin-components": "^1.0.0-alpha.3",
     "recharts": "^2.1.13",
     "yup": "^0.32.11"
   },
@@ -440,6 +440,6 @@
       "workbox-core": "6.5.0",
       "workbox-precaching": "6.5.0"
     },
-    "hash": "62f1eeb37c11495e07839b987520330aa3077d6912bd693b72955ace64883d89"
+    "hash": "e0871bdf2db67bfa6bce30cf293ae16ede3f55722c51cb0278c88f8e833567d6"
   }
 }


### PR DESCRIPTION
Notable fixes:
- [fix: use any for event map generic type](https://github.com/tomivirkki/react-vaadin-components/commit/cedbf86a54239b9df04c1d0f4f4e9237fb12a463)
  - Enables using a generic type `Contact` in the `GridActiveItemChangedEvent`
- [fix: don't remove the shadowroot template element](https://github.com/tomivirkki/react-vaadin-components/commit/bdad249406e5699b429e929640ace2a875b4868a)
  - Eliminates the exception that occurred when navigating between the views on FF / Safari